### PR TITLE
PTS-1388 fix travis yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A neat way to trigger JS when media queries change.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Hearst-Hatchery/on-media-query.git"
+    "url": "git@github.com:Hearst-Hatchery/on-media-query.git"
   },
   "author": "Hearst Magazines, forked from https://github.com/JoshBarr/on-media-query",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A neat way to trigger JS when media queries change.",
   "repository": {
     "type": "git",
-    "url": "git@github.com:Hearst-Hatchery/on-media-query.git"
+    "url": "git+ssh://git@github.com:Hearst-Hatchery/on-media-query.git"
   },
   "author": "Hearst Magazines, forked from https://github.com/JoshBarr/on-media-query",
   "license": "MIT",


### PR DESCRIPTION
### JIRA Issue
[https://thetower.atlassian.net/browse/PTS-1388](https://thetower.atlassian.net/browse/PTS-1388)

### Other repos + connected PRs
- [mp-bower-assets/pull/157](https://github.com/Hearst-Hatchery/mp-bower-assets/pull/157)
- [mediaplatform-edit-interface/pull/3118](https://github.com/Hearst-Hatchery/mediaplatform-edit-interface/pull/3118)

### Description
Travis builds often (intermittently) fail due to the `yarn install` task failing to install this repository. The bug seems due to the Dockerfile run script doing a rewrite on GitHub urls that are for Hearst repos. 

The current syntax `git+https://...` is not valid AFAIK because this is a private repo and only `git+ssh` will work. It makes sense that it does not fail every time, for it succeeds when it attempts to use the git protocol.

Also the `sed` query in Edit UI's Dockerfile does not replace that url structure as-is:
```bash
echo ${url} | sed -e "s|git+ssh://git@github.com:|https://$GITHUB_TOKEN:x-oauth-basic@github.com/|g"
# ...
---
IN:  git+ssh://git@github.com:Hearst-Hatchery/on-media-query.git#develop
OUT: https://234567890876546789087REMOVED:x-oauth-basic@github.com/Hearst-Hatchery/on-media-query.git#develop
---
---
IN:  git+https://github.com/Hearst-Hatchery/on-media-query.git
OUT: git+https://github.com/Hearst-Hatchery/on-media-query.git
---
```